### PR TITLE
Ensure long metadata lines aren't wrapped

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,22 +15,18 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["2.7", "3.10"]
-        exclude:
-          - os: windows-latest
-            python-version: "2.7"
+        python-version: ["3.7", "3.12"]
 
     steps:
-      - uses: "actions/checkout@v3"
-      - uses: "actions/setup-python@v4"
+      - uses: "actions/checkout@v4"
+      - uses: "actions/setup-python@v5"
         with:
           python-version: "${{ matrix.python-version }}"
       - name: "Install"
         run: "python -m pip install . pytest-cov wheel"
       - name: "Run tests for ${{ matrix.python-version }} on ${{ matrix.os }}"
         run: python -m pytest --cov=setuptools_ext
-
       - name: Upload coverage to Codecov
         uses: "codecov/codecov-action@v3"
         with:
-          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "setuptools-ext"
-version = "0.5"
+version = "0.6"
+requires-python = ">= 3.7"
 description = "Extension of setuptools to support all core metadata fields"
 authors = [
     {name = "Wim Glenn"},
@@ -14,17 +15,8 @@ readme = "README.rst"
 keywords = ["setuptools", "packaging", "metadata"]
 license = {text = "MIT"}
 dependencies = [
-    "setuptools >= 61.0.0; python_version >= '3.7'",
-    "setuptools",
-    "toml; python_version < '3.11'",
-    "pathlib2; python_version < '3.5'",
-]
-
-[project.optional-dependencies]
-test = [
-    "pytest",
-    "pytest-cov",
-    "wheel",
+    "setuptools >= 61.0.0",
+    "tomli; python_version < '3.11'",
 ]
 
 [project.urls]


### PR DESCRIPTION
Closes #9.

Also:
- Drop Python 2.7 support (Python 3.7+ required)
- Switch Python < 3.11 toml parser from [toml](https://pypi.org/project/toml/) to [tomli](https://pypi.org/project/toml/)