### PR TITLE
Generalise the wheel update procedure, thus making it easy for other backends to do the same tricks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,9 +13,16 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        exclude:
+          - os: macos-latest
+            python-version: "3.7"
+        include:
+          - os: macos-13
+            python-version: "3.7"
 
     steps:
       - uses: "actions/checkout@v4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "setuptools-ext"
-version = "0.6"
+version = "0.7"
 requires-python = ">= 3.7"
 description = "Extension of setuptools to support all core metadata fields"
 authors = [

--- a/setuptools_ext.py
+++ b/setuptools_ext.py
@@ -2,10 +2,13 @@
 import base64
 import email.policy
 import hashlib
+import zipfile
 from pathlib import Path
+import typing
+import shutil
 from zipfile import ZipFile
 
-from setuptools.build_meta import *
+from setuptools.build_meta import *  # noqa
 from setuptools.build_meta import build_wheel as orig_build_wheel
 try:
     # stdlib Python 3.11+
@@ -76,6 +79,111 @@ def rewrite_record(data, new_line):
     return "\n".join(lines).encode()
 
 
+class WheelRecord:
+    # See https://packaging.python.org/en/latest/specifications/binary-distribution-format/#signed-wheel-files
+    def __init__(self, record_content: str = ""):
+        self._records = {}
+        if record_content:
+            self.update_from_record(record_content)
+
+    def update_from_record(self, record_content: typing.Union[str, "WheelRecord"]) -> None:
+        """
+        Update this WheelRecord given another WheelRecord, or RECORD contents
+        """
+        if isinstance(record_content, WheelRecord):
+            record_content = record_content.record_contents()
+        for line in record_content.splitlines():
+            path, file_hash, length = line.split(',')
+            self._records[path] = (file_hash, length)
+
+    def record_file(self, filename, file_content: typing.Union[bytes, str]):
+        """
+        Record the filename and appropriate digests of its contents
+        """
+        digest = hashlib.sha256(file_content).digest()
+        checksum = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+        self._records[filename] = (f'sha256={checksum}', len(file_content))
+
+    def record_contents(self) -> str:
+        contents = []
+        for path, (file_hash, length) in self._records.items():
+            contents.append(f"{path},{file_hash},{length}")
+        return '\n'.join(contents)
+
+
+class WheelModifier:
+    """
+    Representation of an existing wheel with lazily modified contents that
+    can be written on-demand with the write_wheel method.
+
+    """
+    def __init__(self, wheel_zipfile: zipfile.ZipFile):
+        self._wheel_zipfile = wheel_zipfile
+        # Track updated file contents.
+        self._updates = {}
+
+    def dist_info_dirname(self):
+        for filename in self._wheel_zipfile.namelist():
+            # TODO: We could use the filename of the zipfile... but we don't
+            #  necessarily have it.
+            if filename.endswith(".dist-info/METADATA"):
+                return filename.rsplit('/', 1)[0]
+
+    def read(self, filename: str) -> bytes:
+        if filename in self._updates:
+            return self._updates[filename][1]
+        else:
+            return self._wheel_zipfile.read(filename)
+
+    def namelist(self) -> typing.List[str]:
+        names = self._wheel_zipfile.namelist()
+        for filename in self._updates:
+            if filename not in names:
+                names.append(filename)
+        return names
+
+    def zipinfo(self, filename: str) -> zipfile.ZipInfo:
+        if filename in self._updates:
+            return self._updates[0]
+        return self._wheel_zipfile.getinfo(filename)
+
+    def write(self, filename: typing.Union[str, zipfile.ZipInfo], content: bytes, ) -> None:
+        if isinstance(filename, zipfile.ZipFile):
+            zip_info = filename
+            filename = zip_info.filename
+        else:
+            try:
+                zip_info = self.zipinfo(filename)
+            except KeyError:
+                raise ValueError(
+                    f'Unable to write filename {filename} as there is no existing '
+                    'file information in the archive. Please provide a zipinfo'
+                    'instance when writing.'
+                )
+        self._updates[filename] = zip_info, content
+
+    def write_wheel(self, file: typing.Union[str, Path, typing.IO[bytes]]) -> None:
+        distinfo_dir = self.dist_info_dirname()
+        record_filename = f'{distinfo_dir}/RECORD'
+        orig_record = WheelRecord(self.read(record_filename).decode())
+        with ZipFile(file, "w") as z_out:
+            for zinfo in self._wheel_zipfile.infolist():
+                if zinfo.filename == record_filename:
+                    # We deal with record last.
+                    continue
+                if zinfo.filename in self._updates:
+                    zinfo, content = self._updates.pop(zinfo.filename)
+                    orig_record.record_file(zinfo.filename, content)
+                else:
+                    content = self._wheel_zipfile.read(zinfo.filename)
+                z_out.writestr(zinfo, content)
+            for zinfo, content in self._updates:
+                orig_record.record_file(zinfo.filename, content)
+                z_out.writestr(zinfo, content)
+            record_zinfo = self._wheel_zipfile.getinfo(record_filename)
+            z_out.writestr(record_zinfo, orig_record.record_contents())
+
+
 def rewrite_whl(path, extra_metadata):
     """Add extra fields into the wheel's METADATA file"""
     # It would be a lot simpler if we could have just dropped the additional fields
@@ -87,24 +195,13 @@ def rewrite_whl(path, extra_metadata):
     # be changed later on, but unfortunately for now the only option is to rewrite the
     # generated .whl with our modifications
     tmppath = path.parent.joinpath("." + path.name)
-    checksum = record = None
-    with ZipFile(str(path), "r") as z_in, ZipFile(str(tmppath), "w") as z_out:
-        z_out.comment = z_in.comment
-        for zinfo in z_in.infolist():
-            data = z_in.read(zinfo.filename)
-            if zinfo.filename.endswith(".dist-info/METADATA"):
-                data = rewrite_metadata(data, extra_metadata)
-                digest = hashlib.sha256(data).digest()
-                checksum = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
-                new_line = f"{zinfo.filename},sha256={checksum},{len(data)}"
-            if zinfo.filename.endswith(".dist-info/RECORD"):
-                record = zinfo, data
-                continue
-            z_out.writestr(zinfo, data)
-        if record is not None:
-            record_info, record_data = record
-            if checksum is not None:
-                record_data = rewrite_record(record_data, new_line)
-            z_out.writestr(record_info, record_data)
-    path.write_bytes(tmppath.read_bytes())
-    tmppath.unlink()
+
+    with ZipFile(str(path), "r") as whl_zip:
+        whl = WheelModifier(whl_zip)
+        metadata_filename = f'{whl.dist_info_dirname()}/METADATA'
+        metadata = rewrite_metadata(whl.read(metadata_filename), extra_metadata)
+        whl.write(metadata_filename, metadata)
+        with tmppath.open('wb') as whl_fh:
+            whl.write_wheel(whl_fh)
+
+    shutil.move(tmppath, path)

--- a/setuptools_ext.py
+++ b/setuptools_ext.py
@@ -97,7 +97,7 @@ class WheelRecord:
             record_content = record_content.record_contents()
         for line in record_content.splitlines():
             path, file_hash, length = line.split(",")
-            self._records[path] = (file_hash, length)
+            self._records[path] = file_hash, length
 
     def record_file(self, filename, file_content: typing.Union[bytes, str]):
         """
@@ -107,7 +107,7 @@ class WheelRecord:
             file_content = file_content.encode("utf-8")
         digest = hashlib.sha256(file_content).digest()
         checksum = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
-        self._records[filename] = (f"sha256={checksum}", str(len(file_content)))
+        self._records[filename] = f"sha256={checksum}", str(len(file_content))
 
     def record_contents(self) -> str:
         """


### PR DESCRIPTION
I'm facing the case where I want to do the same dist-info modification as ``setuptools-ext``, but specialised for my use-case (I want to be able to modify/inject a project's requirements at build time). I figured there is some generalisation that could be done in ``setuptools-ext`` which would make this much easier to achieve - the result is the beginning of an interface to conveniently modify a Wheel (I wish this existed, but I didn't find [``wheelfile``](https://github.com/MrMino/wheelfile) to be that interface). I can imagine pulling some of this out into its own library at some point, but for now, it is enough to know that it is useful for at least 2 consumers (``setuptools-ext`` and my own work).

Would really value your thoughts and feedback here.