### PR TITLE
Indicate setuptools-ext version in WHEEL file

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,14 +2,16 @@ name: tests
 
 on:
   push:
-    branches: ["main"]
+    branches:
+    - main
   pull_request:
-    branches: ["main"]
+    branches:
+    - main
   workflow_dispatch:
 
 jobs:
   tests:
-    name: "Python ${{ matrix.python-version }} on ${{ matrix.os }}"
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -25,15 +27,15 @@ jobs:
             python-version: "3.7"
 
     steps:
-      - uses: "actions/checkout@v4"
-      - uses: "actions/setup-python@v5"
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "${{ matrix.python-version }}"
-      - name: "Install"
-        run: "python -m pip install . pytest-cov wheel"
-      - name: "Run tests for ${{ matrix.python-version }} on ${{ matrix.os }}"
+          python-version: ${{ matrix.python-version }}
+      - name: Install
+        run: pip install . pytest-cov wheel
+      - name: Run tests for ${{ matrix.python-version }} on ${{ matrix.os }}
         run: python -m pytest --cov=setuptools_ext
       - name: Upload coverage to Codecov
-        uses: "codecov/codecov-action@v3"
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
 [build-system]
-requires = ["setuptools"]
+requires = [
+    "setuptools >= 61.0.0",
+    "tomli; python_version < '3.11'",
+    "importlib_metadata; python_version < '3.8'",
+]
 build-backend = "setuptools_ext"
 backend-path = ["."]
 
@@ -18,6 +22,7 @@ license = {text = "MIT"}
 dependencies = [
     "setuptools >= 61.0.0",
     "tomli; python_version < '3.11'",
+    "importlib_metadata; python_version < '3.8'",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
 [build-system]
 requires = ["setuptools"]
-build-backend = "setuptools.build_meta"
+build-backend = "setuptools_ext"
+backend-path = ["."]
 
 [project]
 name = "setuptools-ext"
-version = "0.7"
+version = "0.8"
 requires-python = ">= 3.7"
 description = "Extension of setuptools to support all core metadata fields"
 authors = [

--- a/setuptools_ext.py
+++ b/setuptools_ext.py
@@ -7,7 +7,6 @@ import shutil
 import sys
 import typing
 import zipfile
-from importlib.metadata import version
 from pathlib import Path
 
 from setuptools.build_meta import *  # noqa
@@ -17,6 +16,11 @@ if sys.version_info >= (3, 11):
     import tomllib
 else:
     import tomli as tomllib
+
+if sys.version_info >= (3, 8):
+    from importlib.metadata import version
+else:
+    from importlib_metadata import version
 
 
 allowed_fields = {

--- a/tests/test_setuptools_ext.py
+++ b/tests/test_setuptools_ext.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import os
 import zipfile
 from pathlib import Path
@@ -11,7 +10,7 @@ import setuptools_ext
 here = Path(__file__).absolute().parent
 
 
-example_pyproject_full = """\
+pyproject_full = """\
 [build-system]
 requires = ["setuptools-ext"]
 build-backend = "setuptools_ext"
@@ -45,10 +44,10 @@ bogus-field = "this will be ignored"
 
 example_readme = """\
 this is the first line of the README.rst file
-this is the second line of the README.rst file \N{EM DASH} and it has non-ascii in it"""
+this is the second line of the README.rst file — and it has non-ascii in it"""
 
 
-example_pyproject_minimal = """\
+pyproject_minimal = """\
 [build-system]
 requires = ["setuptools-ext"]
 build-backend = "setuptools_ext"
@@ -101,13 +100,13 @@ Requires-External: make; sys_platform != "win32"
 Supported-Platform: RedHat 8.3
 
 this is the first line of the README.rst file
-this is the second line of the README.rst file \N{EM DASH} and it has non-ascii in it
+this is the second line of the README.rst file — and it has non-ascii in it
 """
 
 
 @pytest.fixture(autouse=True)
-def in_source_tree(tmp_path):
-    tmp_path.joinpath("README.rst").write_text(example_readme)
+def in_srctree(tmp_path):
+    tmp_path.joinpath("README.rst").write_text(example_readme, encoding="utf8")
     prev = os.getcwd()
     os.chdir(str(tmp_path))
     try:
@@ -116,19 +115,19 @@ def in_source_tree(tmp_path):
         os.chdir(prev)
 
 
-def test_build_wheel_pyproject_toml(in_source_tree):
-    in_source_tree.joinpath("pyproject.toml").write_text(example_pyproject_full)
-    whl = setuptools_ext.build_wheel(wheel_directory=str(in_source_tree))
-    with zipfile.ZipFile(str(in_source_tree / whl)) as zf:
+def test_build_wheel_pyproject_toml(in_srctree):
+    in_srctree.joinpath("pyproject.toml").write_text(pyproject_full, encoding="utf8")
+    whl = setuptools_ext.build_wheel(wheel_directory=str(in_srctree))
+    with zipfile.ZipFile(str(in_srctree / whl)) as zf:
         txt = zf.read("example_proj-0.1.dist-info/METADATA").decode()
     assert txt.rstrip() == expected_metadata.rstrip()
 
 
-def test_build_wheel_setup_cfg(in_source_tree):
-    in_source_tree.joinpath("pyproject.toml").write_text(example_pyproject_minimal)
-    in_source_tree.joinpath("setup.cfg").write_text(example_setup_cfg)
-    whl = setuptools_ext.build_wheel(wheel_directory=str(in_source_tree))
-    with zipfile.ZipFile(str(in_source_tree / whl)) as zf:
+def test_build_wheel_setup_cfg(in_srctree):
+    in_srctree.joinpath("pyproject.toml").write_text(pyproject_minimal, encoding="utf8")
+    in_srctree.joinpath("setup.cfg").write_text(example_setup_cfg, encoding="utf8")
+    whl = setuptools_ext.build_wheel(wheel_directory=str(in_srctree))
+    with zipfile.ZipFile(str(in_srctree / whl)) as zf:
         txt = zf.read("example_proj-0.1.dist-info/METADATA").decode()
     assert txt.rstrip() == expected_metadata.rstrip()
 
@@ -155,11 +154,11 @@ def test_drop_unknown():
     assert out_bytes == expected_out_bytes
 
 
-def test_wheel_generator(in_source_tree, monkeypatch):
+def test_wheel_generator(in_srctree, monkeypatch):
     monkeypatch.setattr("setuptools_ext.version", lambda distribution_name: "0.1")
-    in_source_tree.joinpath("pyproject.toml").write_text(example_pyproject_full)
-    whl = setuptools_ext.build_wheel(wheel_directory=str(in_source_tree))
-    with zipfile.ZipFile(str(in_source_tree / whl)) as zf:
+    in_srctree.joinpath("pyproject.toml").write_text(pyproject_full, encoding="utf8")
+    whl = setuptools_ext.build_wheel(wheel_directory=str(in_srctree))
+    with zipfile.ZipFile(str(in_srctree / whl)) as zf:
         txt = zf.read("example_proj-0.1.dist-info/WHEEL").decode()
     [line] = [x for x in txt.splitlines() if x.startswith("Generator: ")]
     assert line.endswith(" + setuptools-ext (0.1)")

--- a/tests/test_setuptools_ext.py
+++ b/tests/test_setuptools_ext.py
@@ -46,7 +46,7 @@ bogus-field = "this will be ignored"
 
 example_readme = """\
 this is the first line of the README.rst file
-this is the second line of the README.rst file"""
+this is the second line of the README.rst file — and it has an EM DASH in it"""
 
 
 example_pyproject_minimal = """\
@@ -102,7 +102,7 @@ Requires-External: make; sys_platform != "win32"
 Supported-Platform: RedHat 8.3
 
 this is the first line of the README.rst file
-this is the second line of the README.rst file
+this is the second line of the README.rst file — and it has an EM DASH in it
 """
 
 
@@ -154,3 +154,12 @@ Version: 1.0
 def test_drop_unknown():
     out_bytes = setuptools_ext.rewrite_metadata(in_bytes, {})
     assert out_bytes == expected_out_bytes
+
+
+def test_wheel_generator(in_source_tree, monkeypatch):
+    monkeypatch.setattr("setuptools_ext.version", lambda distribution_name: "0.1")
+    in_source_tree.joinpath("pyproject.toml").write_text(example_pyproject_full)
+    whl = setuptools_ext.build_wheel(wheel_directory=str(in_source_tree))
+    with zipfile.ZipFile(str(in_source_tree / whl)) as zf:
+        txt = zf.read("example_proj-0.1.dist-info/WHEEL").decode()
+    assert "Generator: bdist_wheel (0.43.0) + setuptools-ext (0.1)" in txt

--- a/tests/test_setuptools_ext.py
+++ b/tests/test_setuptools_ext.py
@@ -162,4 +162,5 @@ def test_wheel_generator(in_source_tree, monkeypatch):
     whl = setuptools_ext.build_wheel(wheel_directory=str(in_source_tree))
     with zipfile.ZipFile(str(in_source_tree / whl)) as zf:
         txt = zf.read("example_proj-0.1.dist-info/WHEEL").decode()
-    assert "Generator: bdist_wheel (0.43.0) + setuptools-ext (0.1)" in txt
+    [line] = [x for x in txt.splitlines() if x.startswith("Generator: ")]
+    assert line.endswith(" + setuptools-ext (0.1)")

--- a/tests/test_setuptools_ext.py
+++ b/tests/test_setuptools_ext.py
@@ -1,5 +1,4 @@
-from __future__ import unicode_literals
-
+# coding: utf-8
 import os
 import zipfile
 from pathlib import Path
@@ -46,7 +45,7 @@ bogus-field = "this will be ignored"
 
 example_readme = """\
 this is the first line of the README.rst file
-this is the second line of the README.rst file — and it has an EM DASH in it"""
+this is the second line of the README.rst file \N{EM DASH} and it has non-ascii in it"""
 
 
 example_pyproject_minimal = """\
@@ -102,7 +101,7 @@ Requires-External: make; sys_platform != "win32"
 Supported-Platform: RedHat 8.3
 
 this is the first line of the README.rst file
-this is the second line of the README.rst file — and it has an EM DASH in it
+this is the second line of the README.rst file \N{EM DASH} and it has non-ascii in it
 """
 
 


### PR DESCRIPTION
Closes https://github.com/wimglenn/setuptools-ext/issues/14
Change to self-hosting (package setuptools-ext using setuptools-ext itself - see https://peps.python.org/pep-0517/#in-tree-build-backends) Better handling of non-ascii characters (see https://github.com/python/cpython/issues/69731)